### PR TITLE
Install CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: EVM
+    - name: Build
+      run: |
+        mkdir build && cd build
+        cmake -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
+        make -j8
+        cd -
+    - name: Archive
+      run: |
+        zip -j evm-llvm-llc-$GITHUB_SHA.zip build/bin/llc
+        shasum -a 256 evm-llvm-llc-$GITHUB_SHA.zip > evm-llvm-llc-$GITHUB_SHA.zip.sha256
+    - name: Upload 
+      uses: actions/upload-artifact@v2
+      with:
+        name: llc-archive
+        path: evm-llvm-llc-*zip*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         mkdir build && cd build
         cmake -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
+        echo ">>> make -j$(nproc)"
         make -j$(nproc)
         cd -
     - name: Archive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ EVM ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ EVM ]
+    branches:
+      - EVM
+    tags:
+      - '**'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         zip -j evm-llvm-llc-$GITHUB_SHA.zip build/bin/llc
         shasum -a 256 evm-llvm-llc-$GITHUB_SHA.zip > evm-llvm-llc-$GITHUB_SHA.zip.sha256
+        cat evm-llvm-llc-$GITHUB_SHA.zip.sha256
     - name: Upload 
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         mkdir build && cd build
         cmake -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
-        make -j8
+        make -j$(nproc)
         cd -
     - name: Archive
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,9 @@ jobs:
       run: |
         mkdir build && cd build
         cmake -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
-        echo ">>> make -j$(nproc)"
-        make -j$(nproc)
+        echo "nproc: $(nproc)"
+        echo ">>> make -j6"
+        make -j6
         cd -
     - name: Archive
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
-        make -j$(nproc)
+        make -j$(nproc) llc
         cd ..
     - name: Archive
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Build
       run: |
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_LINKER=gold -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
         echo "nproc: $(nproc)"
         echo ">>> make -j6"
         make -j6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
         make -j$(nproc)
-        cd -
+        cd ..
     - name: Archive
       run: |
         zip -j evm-llvm-llc-$GITHUB_SHA.zip build/bin/llc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Build
       run: |
         mkdir build && cd build
-        cmake -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
         echo "nproc: $(nproc)"
         echo ">>> make -j6"
         make -j6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Build
       run: |
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_LINKER=gold -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
         echo "nproc: $(nproc)"
         echo ">>> make -j6"
         make -j6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,7 @@ jobs:
       run: |
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
-        echo "nproc: $(nproc)"
-        echo ">>> make -j6"
-        make -j6
+        make -j$(nproc)
         cd -
     - name: Archive
       run: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,31 @@
+# C/C++ with GCC
+# Build your C/C++ project with GCC using make.
+# Add steps that publish test results, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
+
+trigger:
+- master
+- EVM
+- refs/tags/*
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- script: |
+    mkdir build && cd build
+    cmake -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
+    echo nproc: $(nproc)
+    echo ">>> make -j8"
+    make -j8
+    cd ..
+  displayName: 'Build artifacts'
+- task: ArchiveFiles@2
+  inputs:
+   rootFolderOrFile: 'build/bin/llc'
+   includeRootFolder: false
+   archiveType: 'zip'
+   archiveFile: '$(Build.ArtifactStagingDirectory)/evm_llvm-llc.zip'
+- script: |
+    shasum -a 256 $(Build.ArtifactStagingDirectory)/evm_llvm-llc.zip > $(Build.ArtifactStagingDirectory)/evm_llvm-llc.zip.sha256
+  displayName: 'Finalize artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ steps:
   fetchDepth: 1
 - script: |
     mkdir build && cd build
-    cmake -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
+    cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
     echo nproc: $(nproc)
     echo ">>> make -j8"
     make -j8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,6 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
 
 trigger:
-- master
 - EVM
 - refs/tags/*
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,8 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
+- checkout: self
+  fetchDepth: 1
 - script: |
     mkdir build && cd build
     cmake -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,5 +29,6 @@ steps:
 - script: |
     shasum -a 256 $(Build.ArtifactStagingDirectory)/evm_llvm-llc-$(Build.SourceVersion).zip \
     > $(Build.ArtifactStagingDirectory)/evm_llvm-llc-$(Build.SourceVersion).zip.sha256
+    cat $(Build.ArtifactStagingDirectory)/evm_llvm-llc-$(Build.SourceVersion).zip.sha256
   displayName: 'Finalize artifacts'
 - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ steps:
   fetchDepth: 1
 - script: |
     mkdir build && cd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_LINKER=gold -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
+    cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
     echo nproc: $(nproc)
     echo ">>> make -j8"
     make -j8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ steps:
   fetchDepth: 1
 - script: |
     mkdir build && cd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
+    cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_LINKER=gold -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
     echo nproc: $(nproc)
     echo ">>> make -j8"
     make -j8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,8 +25,9 @@ steps:
    rootFolderOrFile: 'build/bin/llc'
    includeRootFolder: false
    archiveType: 'zip'
-   archiveFile: '$(Build.ArtifactStagingDirectory)/evm_llvm-llc.zip'
+   archiveFile: '$(Build.ArtifactStagingDirectory)/evm_llvm-llc-$(Build.SourceVersion).zip'
 - script: |
-    shasum -a 256 $(Build.ArtifactStagingDirectory)/evm_llvm-llc.zip > $(Build.ArtifactStagingDirectory)/evm_llvm-llc.zip.sha256
+    shasum -a 256 $(Build.ArtifactStagingDirectory)/evm_llvm-llc-$(Build.SourceVersion).zip \
+    > $(Build.ArtifactStagingDirectory)/evm_llvm-llc-$(Build.SourceVersion).zip.sha256
   displayName: 'Finalize artifacts'
 - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,9 +17,7 @@ steps:
 - script: |
     mkdir build && cd build
     cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
-    echo nproc: $(nproc)
-    echo ">>> make -j8"
-    make -j8
+    make -j$(nproc)
     cd ..
   displayName: 'Build artifacts'
 - task: ArchiveFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ steps:
 - script: |
     mkdir build && cd build
     cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=EVM -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=EVM ..
-    make -j$(nproc)
+    make -j$(nproc) llc
     cd ..
   displayName: 'Build artifacts'
 - task: ArchiveFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,3 +29,4 @@ steps:
 - script: |
     shasum -a 256 $(Build.ArtifactStagingDirectory)/evm_llvm-llc.zip > $(Build.ArtifactStagingDirectory)/evm_llvm-llc.zip.sha256
   displayName: 'Finalize artifacts'
+- task: PublishBuildArtifacts@1


### PR DESCRIPTION
Drafting CI pipeline installation.

As-is, the change set includes _two_ pipeline options; only one is necessary. We can have a discussion comparing these options (Github vs. Azure), or alternatives, and then remove or change to use only what seems optimal and necessary.

Both pipelines build the `llc` executable and archive it as a `.zip`, retaining the artifact.

Latest builds on my personal fork, for reference:
- https://github.com/meowsbits/evm_llvm/actions/runs/103701569
- https://dev.azure.com/isaaca0624/isaaca/_build/results?buildId=7&view=results

**Next steps** for the CI pipeline could be discussed and implemented here, or in a following one or few PRs. These would probably include, but may not be limited to:
- [ ] Add testing to the pipeline as a predicate for building.
  - [ ] Linting?
- [ ] Automated Github Release drafts including the manufactured archives.
- [ ] Current builds are only provided for Ubuntu.  I'm not sure what the limits of the program are, but I expect we can expand this to cover other wanted OSes as well.

**Pending**:
- [ ] Minor tweaks to the configs to modify parameters using my personal fork to using the upstream repo.
  - [ ] If Azure, possibly setting up the necessary Azure entities and permissions. (Github, I think, is plug-n-play.)
- [ ] Git hashes and/or tags are nice to have in the archive names.

